### PR TITLE
Disable shading for soot

### DIFF
--- a/agent/agent_shade_rules
+++ b/agent/agent_shade_rules
@@ -16,4 +16,3 @@ rule polyglot.** com.code_intelligence.jazzer.third_party.polyglot.@1
 rule ppg.** com.code_intelligence.jazzer.third_party.ppg.@1
 rule pxb.** com.code_intelligence.jazzer.third_party.pxb.@1
 rule scm.** com.code_intelligence.jazzer.third_party.scm.@1
-rule soot.** com.code_intelligence.jazzer.third_party.soot.@1

--- a/agent/verify_shading.sh
+++ b/agent/verify_shading.sh
@@ -35,4 +35,5 @@
     -e '^gexf.xsd$' \
     -e '^XPP3_1.1.3.4d_b4_MIN_VERSION$' \
     -e '^.gitkeep$' \
+    -e '^soot/' \
     -e '^module-info.class$'


### PR DESCRIPTION
Even after the downgrade, soot.dummy.** can't be shaded:
Caused by: java.lang.IllegalArgumentException: Receiver type of JDynamicInvokeExpr must be soot.dummy.InvokeDynamic!

Instead of listing every other subpackage, we disable shading.